### PR TITLE
Fix empty package: Be more specific in the "files" glob-pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "uncertainty-string",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A module for handling physics-style uncertainty-strings, like 1.873(34)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/"
+    "dist/**/*"
   ],
   "scripts": {
     "clean": "node -p \"require('fs').existsSync('dist') && require('fs').rmdirSync('dist', {recursive: true})\"",


### PR DESCRIPTION
Running "npm pack" locally produced a tarball that contains all
the expected files, but when npm publish is being executed by
GitHub actions, then the tarball only contains the Readme and such,
but no actual code!

Hunch: This might be due to the way my minimalistic globbing pattern
is interpreted by different npm versions...

I used: "files": ["dist/"] to include only the dist-folder. I will
now try "files": ["dist/**/*"] to make sure that npm inluces the
files inside the folder as well!