### PR TITLE
Add empty .npmignore file to fix empty-package-issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uncertainty-string",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A module for handling physics-style uncertainty-strings, like 1.873(34)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Issue is described seems to we well-known:

https://github.com/npm/npm/issues/3304

As suggested in that issue, I am adding an empty .npmignore